### PR TITLE
Fix compatibility with Internet Explorer 8

### DIFF
--- a/lib/kazoo.js
+++ b/lib/kazoo.js
@@ -31,19 +31,19 @@
 		}
 	},
 	notifications = {
-		overriding: {
+		"overriding": {
 			key: "overriding_registration",
 			message: "You have overridden an existing registration for this device."
 		},
-		replaced: {
+		"replaced": {
 			key: "replaced_registration",
 			message: "You have been disconnected: someone else has registered this device."
 		},
-		voicemail: {
+		"voicemail": {
 			key: "voicemail_notification",
 			message: "You have one or more voicemail message(s)."
 		},
-		default: {
+		"default": {
 			key: "unknown_notification",
 			message: "You have received a SIP notification."
 		}
@@ -320,8 +320,8 @@
 								});
 							} else {
 								params.onNotified && params.onNotified({
-									key: notifications.default.key,
-									message: notifications.default.message,
+									key: notifications['default'].key,
+									message: notifications['default'].message,
 									source: e
 								});
 							}
@@ -507,8 +507,8 @@
 							}
 							default: {
 								notification = {
-									key: notifications.default.key,
-									message: notifications.default.message
+									key: notifications['default'].key,
+									message: notifications['default'].message
 								}
 							}
 						}


### PR DESCRIPTION
IE 8 handles the 'default' keyword in a weird way that's different from most browsers.  It doesn't allow you to have it as an object attribute unless it's represented as a string.

In this commit we change the instantiation of the notifications object to use strings for keys, and access the default notification object using the associated array method as opposed to object method.
