### PR TITLE
Add methods for showing flash privacy setting and checking for flash microphone permission

### DIFF
--- a/lib/kazoo.js
+++ b/lib/kazoo.js
@@ -676,6 +676,9 @@
 				}
 			}
 			else if(kazoo.version === 'rtmp') {
+				if (!kazoo.hasFlashMicrophonePermission()) {
+                    kazoo.showFlashSettings();
+                }
 				kazoo.rtmp.phone.callProperty('call', 'invite', destination);
 			}
 		}
@@ -733,6 +736,23 @@
 			}
 		}
 	};
+	
+	kazoo.hasFlashMicrophonePermission = function() {
+        if(kazoo.version === 'rtmp') {
+            if('phone' in kazoo.rtmp) {
+                return kazoo.rtmp.phone.getProperty('deviceAllowed');
+            }
+        }
+        return false;
+    };
+
+    kazoo.showFlashSettings = function() {
+        if(kazoo.version === 'rtmp') {
+            if('phone' in kazoo.rtmp) {
+                kazoo.rtmp.phone.callProperty('showSettings');
+            }
+        }
+    };
 
 	window.kazoo = kazoo;
 }());


### PR DESCRIPTION
Changes to webphone client as discussed in this support ticket:
http://help.2600hz.com/requests/10088

The hasFlashMicrophonePermission method checks to see if the user has granted access to the microphone in the flash privacy settings dialog.

The showFlashSettings method forces the privacy settings to be displayed within the div containing the "VideoIO.swf" flash movie.

The expected way these will be used:
- The user logs in and the flash container is passed in to the init() function
- The user attempts to make a call
- hasFlashMicrophonePermission() returns false
- showFlashSettings() is triggered, forcing privacy settings to be shown
- the SendHub client unhides the flash container and shows it along with some help text
