### PR TITLE
Add callerNumber attribute to call object for onIncoming handler

### DIFF
--- a/lib/kazoo.js
+++ b/lib/kazoo.js
@@ -277,7 +277,8 @@
 								reject: function() {
 									rejectCall(e);
 								},
-								callerName: e.o_event.o_message.o_hdr_From.s_display_name
+								callerName: e.o_event.o_message.o_hdr_From.s_display_name,
+                                callerNumber: e.o_event.o_message.o_hdr_From.o_uri.s_user_name
 							};
 
 						e.newSession.addEventListener('*', kazoo.webrtc.eventsListener);
@@ -572,6 +573,18 @@
 						break;
 					}
 					case 'invited': {
+						// Pull caller name and number from the caller id string
+                        var callerIdString = event.args[0];
+                        var matches = /^(.*) <sip:\+?(\d+)@.*$/i.exec(callerIdString);
+                        var callerName, callerNumber;
+                        if (matches && matches.length >= 3) {
+                            callerName = matches[1];
+                            callerNumber = matches[2];
+                        } else {
+                            callerName = event.args[0];
+                            callerNumber = null;
+                        }
+					
 						var call = {
 							accept: function() {
 								phone.callProperty('call', 'accept');
@@ -581,7 +594,8 @@
 							reject: function() {
 								phone.callProperty('call', 'reject', '486 Busy Here');
 							},
-							callerName: event.args[0]
+							callerName: callerName,
+                            callerNumber: callerNumber
 						};
 
 						params.onIncoming && params.onIncoming(call);


### PR DESCRIPTION
These changes add a new attribute to the call object that is passed to the "onIncoming" event handler: callerNumber. This is intended to contain the phone number of the person calling, rather than the display name passed by callerName.

On SendHub, we only want to display the name of the person calling if the callee has added the phone number as a contact.  These changes allow us to display just a phone number instead if such a contact does not exist.
