### PR TITLE
minor spelling mistake fix for proper error display

### DIFF
--- a/lib/dependencies/src/tinySIP/src/tsip_stack.js
+++ b/lib/dependencies/src/tinySIP/src/tsip_stack.js
@@ -874,7 +874,7 @@ function __tsip_stack_transport_callback(evt) {
         case tsip_transport_event_type_e.STOPPED:
             {
                 if (o_stack.e_state == tsip_transport_state_e.STARTING) {
-                    o_stack.signal(tsip_event_code_e.STACK_FAILED_TO_START, "Failed to connet to the server");
+                    o_stack.signal(tsip_event_code_e.STACK_FAILED_TO_START, "Failed to connect to the server");
                 }
                 else {
                     o_stack.signal(tsip_event_code_e.STACK_STOPPED, "Stack stopped");


### PR DESCRIPTION
Minor spelling mistake fix because we're surfacing error messages to users in some cases.
