### PR TITLE
LWP-1: Don't remove video track when selecting none as video

### DIFF
--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -495,12 +495,8 @@ export default class {
     this._libwebphone.on(
       "mediaDevices.video.input.changed",
       (lwp, mediaDevices, newTrack) => {
-        if (this.hasSession()) {
-          if (newTrack) {
-            this.replaceSenderTrack(newTrack.track);
-          } else {
-            this.removeSenderTrack("video");
-          }
+        if (this.hasSession() && newTrack) {
+          this.replaceSenderTrack(newTrack.track);
         }
       }
     );

--- a/src/lwpMediaDevices.js
+++ b/src/lwpMediaDevices.js
@@ -106,7 +106,7 @@ export default class extends lwpRenderer {
   toggleMute(deviceKind = null) {
     switch (deviceKind) {
       case "audiooutput":
-        return this._toggleUuteOutput(deviceKind);
+        return this._toggleMuteOutput(deviceKind);
       default:
         return this._toggleMuteInput(deviceKind);
     }
@@ -792,24 +792,34 @@ export default class extends lwpRenderer {
             );
           }
         });
-      } else {
-        this._availableDevices[preferedDevice.deviceKind].forEach(
-          (availableDevice) => {
-            if (availableDevice.id == "none") {
-              availableDevice.selected = true;
-            } else {
-              availableDevice.selected = false;
-            }
-          }
-        );
-
-        this._emit(
-          trackKind + ".input.changed",
-          this,
-          null,
-          previousTrackParameters
-        );
       }
+
+      if (trackKind === "video" && preferedDevice.id === "none") {
+        this._startedStreams.forEach((request) => {
+          if (request.mediaStream) {
+            request.mediaStream.getVideoTracks().forEach((track) => {
+              track.enabled = false;
+            });
+          }
+        });
+      }
+
+      this._availableDevices[preferedDevice.deviceKind].forEach(
+        (availableDevice) => {
+          if (availableDevice.id == "none") {
+            availableDevice.selected = true;
+          } else {
+            availableDevice.selected = false;
+          }
+        }
+      );
+
+      this._emit(
+        trackKind + ".input.changed",
+        this,
+        null,
+        previousTrackParameters
+      );
     });
   }
 


### PR DESCRIPTION
Fixes a bug where selecting **none** as your video device won't allow you to re enable video by selecting another video device.