### PR TITLE
COC-197: Add options parameter in call method

### DIFF
--- a/docs/lwpUserAgent.md
+++ b/docs/lwpUserAgent.md
@@ -113,13 +113,12 @@ Returns:
 
 Updates the redial target.
 
-#### call(target, custom_headers, anonymous)
+#### call(target, custom_headers, anonymous, options)
 
 | Name   | Type   | Default | Description                 |
 | ------ | ------ | ------- | --------------------------- |
 | target | string |         | The target for the new call |
-| custom_headers | array |   []      | A list of strings to add to the INVITE |
-| anonymous | boolean |    false     | Whether the call should be done anonymously |
+| call_options | object |    {}     |  [jssip UA.call()](https://jssip.net/documentation/3.4.x/api/ua/#method_call) options parameter |
 
 Attempts to create a new call to target, or the redial target if non is provided
 as an argument.
@@ -132,6 +131,8 @@ calls first ensuring only one call is active at a time.
 
 If custom_headers are provided they will be merged with any configured headers.  The
 format of each string should be the full, valid SIP header.  For example: "X-Foo: bar"
+
+If options are provided they will be merged as part of the jssip UA.call() options
 
 #### hangupAll()
 

--- a/src/lwpUserAgent.js
+++ b/src/lwpUserAgent.js
@@ -217,12 +217,14 @@ export default class extends lwpRenderer {
     this._emit("redial.update", this, this._redialTarget);
   }
 
-  call(target = null, custom_headers = [], anonymous = false) {
+  call(target = null, call_options = {}) {
     let options = {
+      ...call_options,
       data: { lwpStreamId: lwpUtils.uuid() },
-      extraHeaders: [...custom_headers, ...this._config.custom_headers.establish_call],
-      anonymous: anonymous
+      extraHeaders: [...(call_options.extraHeaders || []), ...this._config.custom_headers.establish_call],
+      anonymous: call_options.anonymous || false
     };
+
     const mediaDevices = this._libwebphone.getMediaDevices();
     const callList = this._libwebphone.getCallList();
 


### PR DESCRIPTION
With these options a `Libwebphone` instance is able to set the JsSip's `UA.call()` `options` parameter

https://jssip.net/documentation/3.4.x/api/ua/#method_call