### PR TITLE
fix: use event listener for device change instead of event property

### DIFF
--- a/src/lwpMediaDevices.js
+++ b/src/lwpMediaDevices.js
@@ -549,9 +549,9 @@ export default class extends lwpRenderer {
     });
 
     if (this._config.detectDeviceChanges) {
-      navigator.mediaDevices.ondevicechange = () => {
+      navigator.mediaDevices.addEventListener("devicechange", () => {
         this.refreshAvailableDevices();
-      };
+      });
     }
 
     this._libwebphone.on("audioContext.preview.loopback.started", () => {
@@ -944,7 +944,7 @@ export default class extends lwpRenderer {
                 otherMediaStream.getTracks().forEach((track) => {
                   this._addTrack(mediaStream, track);
                 });
-      
+
                 return mediaStream;
               })
               .then((mediaStream) => {


### PR DESCRIPTION
# change 
use event listener for device change instead of event property
# description
This will allow the library to register multiple listeners for the `devicechange` event and decrease the possibility of the default library listener to not being overridden. 