### PR TITLE
Add getCustomHeaders to lwpCall

### DIFF
--- a/docs/lwpCall.md
+++ b/docs/lwpCall.md
@@ -410,6 +410,21 @@ Returns:
 callId hassession progress established ended hold muted primary inTransfer
 direction terminating originating localIdentity remoteIdentity
 
+#### getCustomHeaders()
+
+List of custom headers sent, custom headers starting with X-
+
+Returns:
+
+The return is an Object with the properties key, value associated with each of the custom headers.
+
+```json
+{
+  "X-CustomHeader": "present",
+  "X-AnotherHeader": "anotherValue"
+}
+```
+
 ## Configuration
 
 | Name                  | Type     | Default | Description                                                                                                                                       |

--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -411,6 +411,23 @@ export default class {
     };
   }
 
+  getCustomHeaders() {
+    const session = this._getSession();
+    const request = session._request;
+    if (request && request.headers) {
+      return Object.keys(request.headers).reduce((customHeaders, headerName) => {
+        // make sure it's a custom header
+        if (headerName.startsWith('X-')) {
+          const headerValue = request.headers[headerName];
+          if (headerValue && Array.isArray(headerValue)) {
+            customHeaders[headerName] = headerValue.map(header => header.raw).toString();
+          }
+        }
+        return customHeaders;
+      }, {})
+    }
+  }  
+
   /** Init functions */
 
   _initProperties() {


### PR DESCRIPTION
I added a method in lwpCall to return the list of custom headers from a call as I needed to implement a logic where calls tagged with a certain header will be answered automatically.

```javascript
if (currentCall.isInProgress()) {
  const customHeaders = currentCall.getCustomHeaders()
  if (customHeaders && customHeaders['X-IntegratedCall'] === 'true') {
    return currentCall.answer()
  }
}
```