### PR TITLE
Add missing renderTarget for userAgent config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The library provides multiple ways to interact with it. The quick start example 
                renderTargets: ["audio_context"],
             },
             userAgent: {
+               renderTargets: ['user_agent'],
                transport: {
                   sockets: ["wss://sip.websocket.server"],
                },


### PR DESCRIPTION
# Fix for missing config value in the readme

The readme example code is missing a renderTarget value for the userAgent. Without this the basic boilerplate code given in the readme will throw an exception because it expects that value to be there.