### PR TITLE
feat(auto-answer): Update lwpCall.js to support auto-answer

### DIFF
--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -24,6 +24,15 @@ export default class lwpCall {
     if (session) {
       this._timeUpdate();
     }
+
+    if (this._shouldAutoAnswer()) {
+      this.answer();
+    }
+  }
+
+  _shouldAutoAnswer() {
+    return this._session?._request?.headers["Call-Info"]
+      && this._session._request.headers["Call-Info"][0].raw.includes("answer-after=0");
   }
 
   getId() {
@@ -526,7 +535,7 @@ export default class lwpCall {
       });
     });
 
-    if (this.isRinging()) {
+    if (this.isRinging() && !this._shouldAutoAnswer()) {
       this._emit("ringing.started", this);
     }
   }


### PR DESCRIPTION
# Description

Maybe this will speed up your work on your end. I took a stab and implementing this and found a working solution to recognize the `answer-after=0` in the `Call-Info` header.

When we see this we will answer the call immediately and also don't start ringing when that header is present.

This was verified working for calls that had the correct header.