### PR TITLE
LWP-7: make the auto-answer optional and compatable with older JS

### DIFF
--- a/docs/lwpCall.md
+++ b/docs/lwpCall.md
@@ -429,6 +429,7 @@ direction terminating originating localIdentity remoteIdentity
 
 | Name                  | Type     | Default | Description                                                                                                                                       |
 | --------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| autoAnswer             | boolean | true    | If set to false the phone will not honor the auto-answer=0 header, requiring the user to always explicitly answer all calls                       |
 | useAudioContext       | boolean  | false   | Should the lwpAudioContext be used as the destination for the remote audio. See note.                                                             |
 | globalKeyShortcuts    | boolean  | true    | Should the event listeners in the 'keys' property be added to the document                                                                        |
 | keys.spacebar.enabled | boolean  | true    | If true, and globalKeyShortcuts is also true, preform keys.spacebar.action if the spacebar is pressed when the body of the document has the focus |

--- a/src/libwebphone.js
+++ b/src/libwebphone.js
@@ -122,6 +122,7 @@ export default class extends EventEmitter {
       userAgent: { enabled: true },
       videoCanvas: { enabled: true },
       call: {
+        autoAnswer: true,
         useAudioContext: false,
         globalKeyShortcuts: true,
         startWithAudioMuted: false,

--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -31,8 +31,18 @@ export default class lwpCall {
   }
 
   _shouldAutoAnswer() {
-    return this._session?._request?.headers["Call-Info"]
-      && this._session._request.headers["Call-Info"][0].raw.includes("answer-after=0");
+    // Return false if autoAnswer is explicitly set to false
+    if (this._config.autoAnswer === false) {
+      return false;
+    }
+  
+    // Check for the presence of Call-Info header and the "answer-after=0" value
+    if (this._session && this._session._request && this._session._request.headers && this._session._request.headers["Call-Info"]) {
+      const callInfo = this._session._request.headers["Call-Info"][0].raw;
+      return callInfo.includes("answer-after=0");
+    }
+  
+    return false;
   }
 
   getId() {


### PR DESCRIPTION
Make the new auto-answer feature a configuration option to disable it, defaults to enabled.  Additionally, refactored the optional chaining with if statements to ensure compatibility with older JS versions.