### PR TITLE
LWP-5: Adds call waiting tone and functionality

### DIFF
--- a/docs/lwpAudioContext.md
+++ b/docs/lwpAudioContext.md
@@ -4,7 +4,9 @@
 
 The libwebphone audio context class contains all the functionality related to the browsers [AudioContext](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext). This is used to generate ringing audio, DTMF tones, and provide volume controls.
 
-Ringing audio is created by modulating a generated sine wave, then cycling the result between audible and muted.
+Default ringtone audio is created by mixing of two sine wave generators/oscilators with different frequencies, result is rendered to in-memory buffer and then played back in a loop when ringing is required. Default configuration settings produce [US standard ring tone](https://en.wikipedia.org/wiki/Ringing_tone#Bell_System_tones): mix of 440Hz and 480Hz sine waves for 2 seconds followed by 4 seconds of silence.
+
+Call waiting ringtone audio is created by one sine wave generator, result is again rendered to in-memory buffer and then played back in a loop when this ring tone is required. Default configuration settings produce [ZIP tone](https://en.wikipedia.org/wiki/Zip_tone): 440Hz - 300 milliseconds beep once per 10 seconds.
 
 Tones are created by creating an audio buffer containing the calculated values of one or more sine wave frequencies provided as arguments at a sample rate of 8000 for the configured duration (channels.tone.duration). This audio buffer is played then destroyed.
 
@@ -178,40 +180,42 @@ Re-paint / update all render targets.
 
 ## Configuration
 
-| Name                                | Type     | Default | Description                                                                                                                                          |
-| ----------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| channels.master.show                | boolean  | true    | Should the default template show the master volume control                                                                                           |
-| channels.master.volume              | float    | 1.0     | The initial volume of the master audio, where 0 is muted and 1 is 100%                                                                               |
-| channels.ringer.show                | boolean  | true    | Should the default template show the ringing volume control                                                                                          |
-| channels.ringer.volume              | float    | 1.0     | The initial volume of the ringing audio, where 0 is muted and 1 is 100%                                                                              |
-| channels.ringer.connectToMaster     | boolean  | true    | Should the ringing audio play through the master channel                                                                                             |
-| channels.ringer.onTime              | float    | 1.5     | Duration, in seconds, the ringing sound should be audible each cycle                                                                                 |
-| channels.ringer.offTime             | float    | 1.0     | Duration, in seconds, the ringing sound should be muted each cycle                                                                                   |
-| channels.ringer.carrier.frequency   | float    | 440     | Frequency of the ringing sound generator carrier                                                                                                     |
-| channels.ringer.modulator.frequency | float    | 10      | Frequency of the ring sound generator volume modulator                                                                                               |
-| channels.ringer.modulator.amplitude | float    | 0.75    | The amount the modulator should change the carrier volume, where 0 is none and 1 is 100%                                                             |
-| channels.tones.show                 | boolean  | true    | Should the default template show the DTMF playback tones volume control                                                                              |
-| channels.tones.volume               | float    | 0.15    | The initial volume of the DTMF playback tones                                                                                                        |
-| channels.tones.duration             | float    | 0.15    | Duration, in seconds, that the DTMF playback tones should be audible for                                                                             |
-| channels.tones.connectToMaster      | boolean  | true    | Should the DTMF playback tones play through the master channel                                                                                       |
-| channels.remote.show                | boolean  | true    | Should the default template show the remote (call) volume                                                                                            |
-| channels.remote.volume              | float    | 1.0     | The initial volume of any remote audio (call)                                                                                                        |
-| channels.remote.connectToMaster     | boolean  | false   | Should the remote audio (calls) play through the master channel                                                                                      |
-| channels.preview.show               | boolean  | true    | Should the default template show the preview volume                                                                                                  |
-| channels.preview.volume             | float    | 1.0     | The initial volume of any preview audio                                                                                                              |
-| channels.preview.connectToMaster    | boolean  | false   | Should the preview audio play through the master channel                                                                                             |
-| channels.preview.loopback.delay     | float    | 0.5     | Duration, in seconds, to delay the microphone audio when the loopback preview is playing                                                             |
-| channels.preview.tone.frequency     | integer  | 440     | The frequency of the preview tone                                                                                                                    |
-| channels.preview.tone.duration      | integer  | 1.5     | The duration, in seconds, to play the preview tone                                                                                                   |
-| channels.preview.tone.type          | string   | sine    | The waveform type to generate (sine, square, sawtooth, triangle)                                                                                     |
-| globalKeyShortcuts                  | boolean  | true    | Should the event listeners in the 'keys' property be added to the document                                                                           |
-| keys.arrowup.enabled                | boolean  | true    | If true, and globalKeyShortcuts is also true, preform keys.arrowup.action if the up arrow is pressed when the body of the document has the focus     |
-| keys.arrowup.action                 | function |         | By default this callback increases the master volume by 5% (0.05)                                                                                    |
+| Name                                | Type     | Default | Description                                                                               |
+| ----------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------- |
+| channels.master.show                | boolean  | true    | Should the default template show the master volume control                                |
+| channels.master.volume              | float    | 1.0     | The initial volume of the master audio, where 0 is muted and 1 is 100%                    |
+| channels.ringer.show                | boolean  | true    | Should the default template show the ringing volume control                               |
+| channels.ringer.volume              | float    | 1.0     | The initial volume of the ringing audio, where 0 is muted and 1 is 100%                   |
+| channels.ringer.connectToMaster     | boolean  | true    | Should the ringing audio play through the master channel                                  |
+| channels.ringer.default.onTime      | float    | 2       | Duration, in seconds, the ringing sound should be audible each default ring tone cycle    |
+| channels.ringer.default.<br>&emsp;sequenceDuration | float    | 6     | Duration, in seconds, of one default ring tone cycle                         |
+| channels.ringer.default.<br>&emsp;oscilator_1.frequency | float    | 440     | Frequency of the first oscilator of the `default` ring tone           |
+| channels.ringer.default.<br>&emsp;oscilator_2.frequency | float    | 480     | Frequency of the second oscilator of the `default` ring tone          |
+| channels.ringer.callWaiting.onTime  | float    | 0.3     | Duration, in seconds, the ringing sound should be audible each `call waiting` ring tone cycle |
+| channels.ringer.callWaiting.<br>&emsp;sequenceDuration | float    | 10     | Duration, in seconds, of one `call waiting` ring tone cycle             |
+| channels.ringer.callWaiting.<br>&emsp;oscilator.frequency | float    | 440     | Frequency of the oscilator of the `call waiting` ring tone          |
+| channels.tones.show                 | boolean  | true    | Should the default template show the DTMF playback tones volume control                   |
+| channels.tones.volume               | float    | 0.15    | The initial volume of the DTMF playback tones                                             |
+| channels.tones.duration             | float    | 0.15    | Duration, in seconds, that the DTMF playback tones should be audible for                  |
+| channels.tones.connectToMaster      | boolean  | true    | Should the DTMF playback tones play through the master channel                            |
+| channels.remote.show                | boolean  | true    | Should the default template show the remote (call) volume                                 |
+| channels.remote.volume              | float    | 1.0     | The initial volume of any remote audio (call)                                             |
+| channels.remote.connectToMaster     | boolean  | false   | Should the remote audio (calls) play through the master channel                           |
+| channels.preview.show               | boolean  | true    | Should the default template show the preview volume                                       |
+| channels.preview.volume             | float    | 1.0     | The initial volume of any preview audio                                                   |
+| channels.preview.connectToMaster    | boolean  | false   | Should the preview audio play through the master channel                                  |
+| channels.preview.loopback.delay     | float    | 0.5     | Duration, in seconds, to delay the microphone audio when the loopback preview is playing  |
+| channels.preview.tone.frequency     | integer  | 440     | The frequency of the preview tone                                                         |
+| channels.preview.tone.duration      | integer  | 1.5     | The duration, in seconds, to play the preview tone                                        |
+| channels.preview.tone.type          | string   | sine    | The waveform type to generate (sine, square, sawtooth, triangle)                          |
+| globalKeyShortcuts                  | boolean  | true    | Should the event listeners in the 'keys' property be added to the document                |
+| keys.arrowup.enabled                | boolean  | true    | If true, and globalKeyShortcuts is also true, preform keys.arrowup.action if the up arrow is pressed when the body of the document has the focus |
+| keys.arrowup.action                 | function |         | By default this callback increases the master volume by 5% (0.05)                         |
 | keys.arrowdown.enabled              | boolean  | true    | If true, and globalKeyShortcuts is also true, preform keys.arrowdown.action if the down arrow is pressed when the body of the document has the focus |
-| keys.arrowdown.action               | function |         | By default this callback decreases the master volume by 5% (0.05)                                                                                    |
-| volumeMax                           | integer  | 100     | The maximum value when converting the volume between floats and integers                                                                             |
-| volumeMin                           | integer  | 0       | The minimum value when converting the volume between floats and integers                                                                             |
-| renderTargets                       | array    | []      | See [lwpRenderer](lwpRenderer.md)                                                                                                                    |
+| keys.arrowdown.action               | function |         | By default this callback decreases the master volume by 5% (0.0                           |
+| volumeMax                           | integer  | 100     | The maximum value when converting the volume between floats and integers                  |
+| volumeMin                           | integer  | 0       | The minimum value when converting the volume between floats and integers                  |
+| renderTargets                       | array    | []      | See [lwpRenderer](lwpRenderer.md)                                                         |
 
 ## Events
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eventemitter2": "^6.2.1",
         "i18next": "^19.8.7",
         "jssip": "^3.7.1",
+        "jwt-decode": "^4.0.0",
         "lodash": "^4.17.15",
         "media-device-id": "^1.0.1",
         "mustache": "^3.1.0",
@@ -3920,6 +3921,15 @@
         "debug": "^4.3.1",
         "events": "^3.3.0",
         "sdp-transform": "^2.14.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/killable": {
@@ -10859,6 +10869,11 @@
         "events": "^3.3.0",
         "sdp-transform": "^2.14.1"
       }
+    },
+    "jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
     },
     "killable": {
       "version": "1.0.1",

--- a/src/lwpAudioContext.js
+++ b/src/lwpAudioContext.js
@@ -24,8 +24,6 @@ export default class extends lwpRenderer {
   startAudioContext() {
     if (!this._started) {
       this._audioContext.resume();
-      this._ringerAudio.carrierNode.start();
-      this._ringerAudio.modulatorNode.start();
       this._previewAudio.oscillatorNode.start();
 
       this._started = true;
@@ -202,22 +200,85 @@ export default class extends lwpRenderer {
     }, (duration + 0.5) * 1000);
   }
 
-  startRinging(requestId = null) {
-    this.startAudioContext();
+    /**
+   * Updates the ringtone buffer based on primary call status
+   * Switches between default ringtone and call waiting tone
+   * @param {Object} call - Optional call object to check status
+   */
+  updateRingtone(call = null) {
+    // Get primary call if none provided
+    const primaryCall = call || this._libwebphone.getCallList().getCall();
+    
+    // Determine if there's an active call = established and not on hold
+    const hasActiveCall = primaryCall && primaryCall.isEstablished() && !primaryCall.isOnHold();
+    
+    // Select appropriate ringtone buffer
+    const newBuffer = hasActiveCall 
+      ? this._ringerAudio.callWaitingToneBuffer 
+      : this._ringerAudio.defaultRingToneBuffer;
+    
+    // Log the change
+    console.log(`AudioContext: switching ring tone to ${hasActiveCall ? 'call waiting' : 'default'} tone`);
+    
+    // Check if ringtone is actively playing
+    const wasActive = this._ringerAudio.isActive;
+    
+    // Update the ringtone buffer
+    this._ringerAudio.ringToneBuffer = newBuffer;
+    
+    // If ringtone is currently active, restart it with new buffer
+    if (wasActive && this._ringerAudio.calls.length > 0) {
+      // Stop current playback
+      if (this._ringerAudio.source) {
+        this._ringerAudio.source.stop();
+      }
+      
+      // Create and start new source with updated buffer
+      this._ringerAudio.source = new AudioBufferSourceNode(this._audioContext, {
+        buffer: this._ringerAudio.ringToneBuffer,
+        loop: true,
+      });
+      
+      // Connect to output chain
+      this._ringerAudio.source
+        .connect(this._ringerAudio.ringerGain)
+        .connect(this._getOutputGainNode("ringer"));
+      
+      this._ringerAudio.source.start();
+    }
+    
+    // Emit event for the ringtone change
+    this._emit("ringtone.updated", this, hasActiveCall ? "callWaiting" : "default");
+  }
 
+  startRinging(requestId = null) {
     if (!requestId) {
       this._ringerAudio.calls.push(null);
     } else if (!this._ringerAudio.calls.includes(requestId)) {
       this._ringerAudio.calls.push(requestId);
     }
 
-    if (!this._ringerAudio.ringerConnected) {
-      this._ringerAudio.ringerConnected = true;
-      this._ringerAudio.ringerGain.connect(this._getOutputGainNode("ringer"));
-    }
 
-    if (!this._ringingTimer) {
-      this._ringTimer();
+    if (this._libwebphone.getCallList().getCall() && this._libwebphone.getCallList().getCall().isEstablished()) {
+      console.log('AudioContext: switching ring tone to call waiting tone');
+      this._ringerAudio.ringToneBuffer = this._ringerAudio.callWaitingToneBuffer;
+    } else {
+      console.log("AudioContext: switching ring tone to default tone");
+      this._ringerAudio.ringToneBuffer = this._ringerAudio.defaultRingToneBuffer;
+    }
+    if (!this._ringerAudio.isActive) {
+      
+      this.startAudioContext();
+
+      this._ringerAudio.source = new AudioBufferSourceNode(this._audioContext, {
+        buffer: this._ringerAudio.ringToneBuffer,
+        loop: true,
+      });
+      this._ringerAudio.source
+        .connect(this._ringerAudio.ringerGain)
+        .connect(this._getOutputGainNode("ringer"));
+      this._ringerAudio.source.start();
+      this._ringerAudio.isActive = true;
     }
   }
 
@@ -238,14 +299,14 @@ export default class extends lwpRenderer {
   }
 
   stopAllRinging() {
-    if (this._ringerAudio.ringerConnected) {
-      this._ringerAudio.ringerConnected = false;
-      this._ringerAudio.ringerGain.disconnect();
+    this._ringerAudio.ringerGain.disconnect();
+    this._ringerAudio.isActive = false;
+    
+    if(this._ringerAudio.source) {
+      this._ringerAudio.source.stop();
     }
 
     this._ringerAudio.calls = [];
-
-    this._ringerMute();
   }
 
   getDestinationStream() {
@@ -286,14 +347,22 @@ export default class extends lwpRenderer {
           volume: 1.0,
         },
         ringer: {
-          onTime: 1.5,
-          offTime: 1.0,
-          carrier: {
-            frequency: 440,
+          default: {
+            onTime: 2,
+            sequenceDuration: 6,
+            oscilator_1: {
+              frequency: 440,
+            },
+            oscilator_2: {
+              frequency: 480,
+            }
           },
-          modulator: {
-            frequency: 10,
-            amplitude: 0.75,
+          callWaiting: {
+            onTime: .3,
+            sequenceDuration: 10,
+            oscilator: {
+              frequency: 440,
+            }
           },
           show: true,
           volume: 1.0,
@@ -425,37 +494,87 @@ export default class extends lwpRenderer {
     }
   }
 
-  _initRingAudio() {
+  async _initRingAudio() {
     this._ringerAudio = {};
 
-    this._ringerAudio.context = this._audioContext;
-
+    var context = this._audioContext;
+    this._ringerAudio.context = context;
     this._ringerAudio.calls = [];
+    this._ringerAudio.isActive = false;
+    this._ringerAudio.ringerGain = this._shimCreateGain(context);
 
-    this._ringerAudio.ringerConnected = false;
+    await this.generateDefaultRingTone();
+    await this.generateCallWaitingTone();
 
-    this._ringerAudio.carrierGain = this._shimCreateGain(
-      this._ringerAudio.context
+    this._ringerAudio.ringToneBuffer = this._ringerAudio.defaultRingToneBuffer;
+  }
+
+  generateDefaultRingTone() {
+    const offlineCtx = new OfflineAudioContext(
+      2
+      ,44100 * this._config.channels.ringer.default.sequenceDuration
+      ,44100
     );
 
-    this._ringerAudio.carrierNode = this._shimCreateOscillator(
-      this._ringerAudio.context
-    );
-    this._ringerAudio.carrierNode.frequency.value =
-      this._config.channels.ringer.carrier.frequency;
-    this._ringerAudio.carrierNode.connect(this._ringerAudio.carrierGain);
+    const osc_1 = new OscillatorNode(offlineCtx, {
+      frequency: this._config.channels.ringer.default.oscilator_1.frequency,
+    });
+    const gain_1 = new GainNode(offlineCtx);
+    gain_1.gain.value = 0.5;
+    osc_1.connect(gain_1);
 
-    this._ringerAudio.modulatorNode = this._shimCreateOscillator(
-      this._ringerAudio.context
-    );
-    this._ringerAudio.modulatorNode.frequency.value =
-      this._config.channels.ringer.modulator.frequency;
-    this._ringerAudio.modulatorNode.connect(this._ringerAudio.carrierGain.gain);
+    const osc_2 = new OscillatorNode(offlineCtx, {
+      frequency: this._config.channels.ringer.default.oscilator_2.frequency,
+    });
+    const gain_2 = new GainNode(offlineCtx);
+    gain_2.gain.value = 0.5;
+    osc_2.connect(gain_2);
 
-    this._ringerAudio.ringerGain = this._shimCreateGain(
-      this._ringerAudio.context
+    const merger = new ChannelMergerNode(offlineCtx);
+    gain_1.connect(merger, 0, 0);
+    gain_2.connect(merger, 0, 1);
+    merger.connect(offlineCtx.destination);
+    osc_1.start(offlineCtx.currentTime);
+    osc_2.start(offlineCtx.currentTime);
+    osc_1.stop(offlineCtx.currentTime + this._config.channels.ringer.default.onTime);
+    osc_2.stop(offlineCtx.currentTime + this._config.channels.ringer.default.onTime);
+
+    return offlineCtx.startRendering().then(
+      (renderedBuffer) => {
+        console.log("AudioContext: default ringer tone rendering completed successfully.");
+        this._ringerAudio.defaultRingToneBuffer = renderedBuffer;
+      })
+      .catch((err) => {
+        console.error(`Error encountered: ${err}`);
+      });
+  }
+
+  generateCallWaitingTone() {
+    const offlineCtx = new OfflineAudioContext(
+      2
+      ,44100 * this._config.channels.ringer.callWaiting.sequenceDuration
+      ,44100
     );
-    this._ringerAudio.carrierGain.connect(this._ringerAudio.ringerGain);
+
+    // code commented out allows to add a second beep to the call waiting tone
+    const osc = new OscillatorNode(offlineCtx, {
+      frequency: this._config.channels.ringer.callWaiting.oscilator.frequency,
+    });
+    
+    const gain = new GainNode(offlineCtx);
+    gain.gain.value = 1;
+    osc.connect(gain);
+    gain.connect(offlineCtx.destination, 0, 0);
+    osc.start(offlineCtx.currentTime);
+    osc.stop(offlineCtx.currentTime + this._config.channels.ringer.callWaiting.onTime);
+    return offlineCtx.startRendering().then(
+      (renderedBuffer) => {
+        console.log("AudioContext: call wait tone rendering completed successfully.");
+        this._ringerAudio.callWaitingToneBuffer = renderedBuffer;
+      })
+      .catch((err) => {
+        console.error(`Error encountered: ${err}`);
+      });
   }
 
   _initTonesAudio() {
@@ -520,6 +639,19 @@ export default class extends lwpRenderer {
         this._createRemoteSourceStream(mediaStream);
       }
     );
+
+    this._libwebphone.on("call.primary.established", (lwp, call) => {
+      this.updateRingtone(call);
+    });
+    this._libwebphone.on("call.primary.hold", (lwp, call) => {
+      this.updateRingtone(call);
+    });
+    this._libwebphone.on("call.primary.unhold", (lwp, call) => {
+      this.updateRingtone(call);
+    });
+    this._libwebphone.on("call.primary.terminated", (lwp, call) => {
+      this.updateRingtone(call);
+    });
 
     this._libwebphone.on("dialpad.tones.play", (lwp, dialpad, tones) => {
       this.playTones.apply(this, tones);
@@ -709,56 +841,6 @@ export default class extends lwpRenderer {
 
   /** Helper functions */
 
-  _ringTimer() {
-    if (this._ringerAudio.calls.length > 0) {
-      if (this._ringerAudio.ringerGain.gain.value < 0.5) {
-        this._ringerUnmute();
-        this._ringingTimer = setTimeout(() => {
-          this._ringTimer();
-        }, this._config.channels.ringer.onTime * 1000);
-      } else {
-        this._ringerMute();
-        this._ringingTimer = setTimeout(() => {
-          this._ringTimer();
-        }, this._config.channels.ringer.offTime * 1000);
-      }
-    } else {
-      if (this._ringingTimer) {
-        clearTimeout(this._ringingTimer);
-        this._ringingTimer = null;
-      }
-
-      if (this._ringerAudio.ringerConnected) {
-        this._ringerAudio.ringerConnected = false;
-        this._ringerAudio.ringerGain.disconnect();
-      }
-    }
-  }
-
-  _ringerMute() {
-    const timestamp =
-      this._ringerAudio.context.currentTime +
-      this._config.channels.ringer.onTime * 0.2;
-
-    this._ringerAudio.ringerGain.gain.cancelScheduledValues(0);
-    this._ringerAudio.ringerGain.gain.exponentialRampToValueAtTime(
-      0.00001,
-      timestamp
-    );
-  }
-
-  _ringerUnmute() {
-    const timestamp =
-      this._ringerAudio.context.currentTime +
-      this._config.channels.ringer.offTime * 0.2;
-
-    this._ringerAudio.ringerGain.gain.cancelScheduledValues(0);
-    this._ringerAudio.ringerGain.gain.exponentialRampToValueAtTime(
-      0.5,
-      timestamp
-    );
-  }
-
   _createLocalMediaStreamSource(mediaStream) {
     return this._shimCreateMediaStreamSource(
       this._previewAudio.context,
@@ -893,6 +975,13 @@ export default class extends lwpRenderer {
 
   _shimCreateOscillator(context, ...args) {
     return (context.createOscillator || context.webkitCreateOscillator).apply(
+      context,
+      args
+    );
+  }
+
+  _shimCreateChannelMerger(context, ...args) {
+    return (context.createChannelMerger || context.webkitCreateChannelMerger).apply(
       context,
       args
     );

--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -742,11 +742,13 @@ export default class lwpCall {
 
   _destroyCall() {
     this._removeEventBindings();
-    this._emit("terminated", this);
 
     if (this.isPrimary()) {
-      this._clearPrimary(false);
+      this._emit("primary.terminated", this);
     }
+
+    this._emit("terminated", this);
+
 
     this._destroyStreams();
 


### PR DESCRIPTION
Adds "call waiting" ringing tone alongside default ring tone + adds related behavior - when to switch between them.

I took the liberty to change how ringtones are generated/played. Now both ringtones are pre-rendered to in-memory buffer using `OfflineAudioContext` and then just played back using `AudioBufferSourceNode` when needed.

Per customer request, call waiting tone is US standard: 440Hz - 300 milliseconds beep once per 10 seconds.

Tone switching is based on observation of `call.primary` events and check of primary call status - if it is active (established and not on hold) ringtone is switched to "call waiting" tone.

Also main ring tone was changed to US standard:
> two-second tone at 440 Hz and 480 Hz, followed by four seconds of silence