### PR TITLE
Fix: don't call setSinkId with preferred deviceId `none`

### DIFF
--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -473,8 +473,22 @@ export default class lwpCall {
         .getMediaDevices()
         .getPreferedDevice(deviceKind);
 
+      // Don't call the setSinkId if video is disabled 
+      // This causes a problem for video with a "none" deviceId
+      // It causes WebRTC to throw an exception when you call setSinkId with
+      // a "none" deviceId.
+      // This is a slight hack to just short circuit here but we're never going
+      // to use videoInput so I'm pretty sure this is ok.
+      //  And it stops the error from happening.
+      if (elementKind === "video" && !this._libwebphone._config.mediaDevices.videoinput.enabled) {
+        return element;
+      }
+
       if (preferedDevice) {
         try {
+          // Here's the offending call to setSinkId that throws an
+          // "Uncaught (in promise) NotFoundError: Requested device not found"
+          // When the preferedDevice.id is "none"
           element.setSinkId(preferedDevice.id);
         } catch (error) {
          this._emit("error", error);


### PR DESCRIPTION
# Description

**DISCLAIMER:**
The code change is likely not the most **correct** fix, but it highlights where the issue is happening.

When you run libwebphone and make/receive a call, you get this annoying exception in the browser console logs:

![image](https://github.com/user-attachments/assets/4d8390e4-1f80-48e0-9251-a3243551e05e)

`Uncaught (in promise) NotFoundError: Requested device not found", source: ... (0)`

This happens when we try to call this code for the `video` element:
```
element.setSinkId(preferedDevice.id);
```

The preferred video device gets created with a `deviceId` of `none` [HERE](https://github.com/2600hz/libwebphone/blob/2ba2da0f73dcc7161556a121b8cce7116bd2421d/src/lwpMediaDevices.js#L463-L469).

Because of this, when the call to `setSinkId()` happens, it looks for a device with `deviceId` of `none` and throws an error.

From the Chrome verbose logging output:
```
[56476:634826:0605/163348.229848:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1504] RFAOSF::RequestDeviceAuthorization({device_id=none}) [process_id=22, frame_id=8]
[56476:634826:0605/163348.229858:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1504] RFAOSF::AuthorizationCompleted({status=ERROR_NOT_FOUND}, {params=format: FAKE, channel_layout: 3, channels: 2, sample_rate: 44100, frames_per_buffer: 441, effects: NONE, mic_positions: }, {device_id=}) [process_id=22, frame_id=8]
```

So my code fix just makes sure you don't call the video `setSinkId()` if video is disabled (which it always is for my own scenario). But there is probably a better way to handle this that is more robust. 

I filed this PR to highlight this issue and I'm sure you don't want all the comments in the code either.