### PR TITLE
LWP-10: Fix error handling in setSinkId() promise

### DIFF
--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -472,13 +472,13 @@ export default class lwpCall {
       const preferedDevice = this._libwebphone
         .getMediaDevices()
         .getPreferedDevice(deviceKind);
-
-      if (preferedDevice) {
-        try {
-          element.setSinkId(preferedDevice.id);
-        } catch (error) {
-         this._emit("error", error);
-        }
+      
+      if (preferedDevice && preferedDevice.id !== "none") {
+        element.setSinkId(preferedDevice.id)
+         .catch ((error) => {
+          console.error("init media element " + elementKind +": " + error);
+          this._emit("error", this, error);
+         });
       }
     }
 
@@ -571,11 +571,11 @@ export default class lwpCall {
       Object.keys(this._streams.remote.elements).forEach((kind) => {
         const element = this._streams.remote.elements[kind];
         if (element && element.setSinkId !== undefined) {
-          try {
-            element.setSinkId(preferedDevice.id);
-          } catch (error) {
-            this._emit("error", error);
-          }
+          element.setSinkId(preferedDevice.id)
+          .catch ((error) => {
+            console.error("media element " + kind +": " + error);
+            this._emit("error", this, error);
+         });
         }
       });
     };

--- a/src/lwpMediaDevices.js
+++ b/src/lwpMediaDevices.js
@@ -786,7 +786,7 @@ export default class extends lwpRenderer {
           }
         })
         .catch((error) => {
-          this._emit("ring.output.error", error);
+          this._emit("ring.output.error", this, error);
         });
     } else {
       this._availableDevices["ringoutput"].forEach((availableDevice) => {
@@ -825,7 +825,7 @@ export default class extends lwpRenderer {
           }
         })
         .catch((error) => {
-          this._emit("audio.output.error", error);
+          this._emit("audio.output.error", this, error);
         });
     } else {
       this._availableDevices[preferedDevice.deviceKind].forEach(


### PR DESCRIPTION
When libwebphone makes or receives call, there is an error in the browser console logs:

`Uncaught (in promise) NotFoundError: Requested device not found, source: ... (0)`

This happens due to this call for the video element: `element.setSinkId(preferedDevice.id);`

The preferred video device gets created with a `deviceId` of `none`. Because of this, when the call to `setSinkId()` happens, it looks for a device with `deviceId` of `none` and throws an error which is not properly handled